### PR TITLE
Replace Harshil Upadhyay with Sahil Patel as WebDev Domain Head on team page

### DIFF
--- a/app/team/team.json
+++ b/app/team/team.json
@@ -48,7 +48,7 @@
             {
                 "id": 4,
                 "name": "Sahil Patel",
-                "role": "Domain Head",
+                "role": "Lead",
                 "avatar": "/team/sahil.jpg",
                 "blur": "/team/tiny/sahil.jpeg",
                 "github": "https://github.com/Sahil-796",

--- a/app/team/team.json
+++ b/app/team/team.json
@@ -47,14 +47,14 @@
         "members": [
             {
                 "id": 4,
-                "name": "Harshil Upadhyay",
-                "role": "Lead",
-                "avatar": "/team/harshil.jpg",
-                "blur": "/team/tiny/harshil.jpeg",
-                "github": "https://github.com/Harshil000",
-                "instagram": null,
-                "x": null,
-                "linkedin": "https://www.linkedin.com/in/harshil-upadhyay-4285b2315?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=android_app"
+                "name": "Sahil Patel",
+                "role": "Domain Head",
+                "avatar": "/team/sahil.jpg",
+                "blur": "/team/tiny/sahil.jpeg",
+                "github": "https://github.com/Sahil-796",
+                "instagram": "https://www.instagram.com/sahil_patel006__",
+                "x": "https://x.com/SahilPa82684047",
+                "linkedin": null
             },
             {
                 "id": 5,


### PR DESCRIPTION
### Motivation
- Update the team listing to remove Harshil Upadhyay from the `WebDev` domain and set Sahil Patel as the WebDev domain head while retaining his existing Leadership entry.

### Description
- Replaced the `WebDev` member entry in `app/team/team.json` (id 4) to use Sahil Patel with role `Domain Head`, reusing Sahil's existing profile details so he appears both under `Leadership` and `WebDev`.

### Testing
- Verified JSON syntax with `python -m json.tool app/team/team.json` which returned OK.
- Started the dev server with `pnpm dev` and loaded `/team` successfully and captured a screenshot; Next.js logged a Google Fonts fetch warning but the page rendered correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee7ea9b1883238d2b7ef883f513cd)